### PR TITLE
remove /v2 from API calls

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -73,7 +73,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 
 		var rootURL = (method.toLowerCase() == 'get') ? "https://cdn-api.ooyala.com" : this.urlRoot;
 
-		request[method.toLowerCase()]( this.urlRoot + apiPath )
+		request[method.toLowerCase()]( rootURL + apiPath )
 			.accept('application/json')
 			.set('X-API-KEY', this.apiKey )
 			.set('HTTP_X_API_KEY', this.apiKey)

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ _ = require('lodash');
 function OoyalaApiClient( apiKey, apiSecret ) {
 	this.apiKey = apiKey;
 	this.apiSecret = apiSecret;
-	this.urlRoot = 'https://api.ooyala.com/v2/';
+	this.urlRoot = 'https://api.ooyala.com/';
 
 	this.concatenateParams = function( params, seperator ) {
 		var string = "";
@@ -41,7 +41,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 	this._generateSignature = function( method, apiPath, params, body ) {
 		var shasum = crypto.createHash('sha256');
 
-		var stringToSign = this.apiSecret + method + "/v2/" + apiPath;
+		var stringToSign = this.apiSecret + method + "/" + apiPath;
 		stringToSign += this.concatenateParams( params, "");
 		stringToSign += body || "";
 		shasum.update( stringToSign );
@@ -71,7 +71,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 		params['expires'] = 30 + Math.floor(Date.now() / 1000);
 		params['signature'] = this._generateSignature( method.toUpperCase(), apiPath, params, body );
 
-		var rootURL = (method.toLowerCase() == 'get') ? "https://cdn-api.ooyala.com/v2/" : this.urlRoot;
+		var rootURL = (method.toLowerCase() == 'get') ? "https://cdn-api.ooyala.com/" : this.urlRoot;
 
 		request[method.toLowerCase()]( this.urlRoot + apiPath )
 			.accept('application/json')

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ _ = require('lodash');
 function OoyalaApiClient( apiKey, apiSecret ) {
 	this.apiKey = apiKey;
 	this.apiSecret = apiSecret;
-	this.urlRoot = 'https://api.ooyala.com/';
+	this.urlRoot = 'https://api.ooyala.com';
 
 	this.concatenateParams = function( params, seperator ) {
 		var string = "";
@@ -41,7 +41,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 	this._generateSignature = function( method, apiPath, params, body ) {
 		var shasum = crypto.createHash('sha256');
 
-		var stringToSign = this.apiSecret + method + "/" + apiPath;
+		var stringToSign = this.apiSecret + method + apiPath;
 		stringToSign += this.concatenateParams( params, "");
 		stringToSign += body || "";
 		shasum.update( stringToSign );
@@ -71,7 +71,7 @@ function OoyalaApiClient( apiKey, apiSecret ) {
 		params['expires'] = 30 + Math.floor(Date.now() / 1000);
 		params['signature'] = this._generateSignature( method.toUpperCase(), apiPath, params, body );
 
-		var rootURL = (method.toLowerCase() == 'get') ? "https://cdn-api.ooyala.com/" : this.urlRoot;
+		var rootURL = (method.toLowerCase() == 'get') ? "https://cdn-api.ooyala.com" : this.urlRoot;
 
 		request[method.toLowerCase()]( this.urlRoot + apiPath )
 			.accept('application/json')


### PR DESCRIPTION
Pagination urls include /v2, so it's tricky to chain calls.  Best to have to include /v2 in the endpoint, as that is what the docs look like as well.
